### PR TITLE
R-1029-15 Ajustar medición del indicador R2I5 del convenio PRM. La suma de personas de casos debe ser de personas distintas (una misma persona puede ir a varias atenciones psicosociales como parte de un proceso, pero debe contar como una).  Suma de participantes en actividades con actividad de convenio R2A6

### DIFF
--- a/app/controllers/cor1440_gen/mindicadorespf_controller.rb
+++ b/app/controllers/cor1440_gen/mindicadorespf_controller.rb
@@ -19,7 +19,6 @@ module Cor1440Gen
         actpf = res.actividadpf.where(id: 349)  # R1A2
       when 214 # R1I3 Número de personas
         actpf = res.actividadpf.where(id: 348)  # ? Relacionado con R1A1
-        #contar = :porcentaje
       when 215 # R1I4 porcentaje
         actpf = res.actividadpf.where(id: 348)  # ? Relacionada con R1A1
         contar = :porcentaje
@@ -116,7 +115,7 @@ module Cor1440Gen
           joins('JOIN sivel2_sjr_actividad_casosjr ON casosjr_id=sivel2_sjr_casosjr.id_caso').
           where('sip_persona.sexo = \'M\'').
           where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac)
-        benef_dir = contactos.count
+        benef_dir = contactos.uniq.count
         idscontactos = contactos.pluck(:contacto_id).uniq
         benef_indir =
           Sivel2Sjr::Victimasjr.joins(:victima).
@@ -125,8 +124,8 @@ module Cor1440Gen
           where('sip_persona.sexo = \'M\'').
           where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).
           where('fechadesagregacion IS NULL OR fechadesagregacion > ?', ffin).
-          where.not(:'sip_persona.id' => idscontactos).count
-
+          where.not(:'sip_persona.id' => idscontactos).uniq.count
+        byebug
         hombres = asistentes + benef_dir + benef_indir
 
         ## CLACULA MUJERES
@@ -140,7 +139,7 @@ module Cor1440Gen
           joins('JOIN sivel2_sjr_actividad_casosjr ON casosjr_id=sivel2_sjr_casosjr.id_caso').
           where('sip_persona.sexo = \'F\'').
           where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac)
-        benef_dir = contactos.count
+        benef_dir = contactos.uniq.count
         idscontactos = contactos.pluck(:contacto_id).uniq
         benef_indir =
           Sivel2Sjr::Victimasjr.joins(:victima).
@@ -149,7 +148,7 @@ module Cor1440Gen
           where('sip_persona.sexo = \'F\'').
           where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).
           where('fechadesagregacion IS NULL OR fechadesagregacion > ?', ffin).
-          where.not(:'sip_persona.id' => idscontactos).count
+          where.not(:'sip_persona.id' => idscontactos).uniq.count
 
         mujeres = asistentes + benef_dir + benef_indir
 
@@ -163,7 +162,7 @@ module Cor1440Gen
           joins('JOIN sivel2_sjr_actividad_casosjr ON casosjr_id=sivel2_sjr_casosjr.id_caso').
           where('sip_persona.sexo <> \'M\' AND sip_persona.sexo <> \'F\'').
           where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac)
-        benef_dir = contactos.count
+        benef_dir = contactos.uniq.count
         idscontactos = contactos.pluck(:contacto_id).uniq
         benef_indir =
           Sivel2Sjr::Victimasjr.joins(:victima).
@@ -172,7 +171,7 @@ module Cor1440Gen
           where('sip_persona.sexo <> \'M\' AND sip_persona.sexo <> \'F\'').
           where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).
           where('fechadesagregacion IS NULL OR fechadesagregacion > ?', ffin).
-          where.not(:'sip_persona.id' => idscontactos).count
+          where.not(:'sip_persona.id' => idscontactos).uniq.count
 
         sinsexo = asistentes + benef_dir + benef_indir
 

--- a/app/controllers/cor1440_gen/mindicadorespf_controller.rb
+++ b/app/controllers/cor1440_gen/mindicadorespf_controller.rb
@@ -19,7 +19,7 @@ module Cor1440Gen
         actpf = res.actividadpf.where(id: 349)  # R1A2
       when 214 # R1I3 Número de personas
         actpf = res.actividadpf.where(id: 348)  # ? Relacionado con R1A1
-        contar = :porcentaje
+        #contar = :porcentaje
       when 215 # R1I4 porcentaje
         actpf = res.actividadpf.where(id: 348)  # ? Relacionada con R1A1
         contar = :porcentaje
@@ -77,7 +77,6 @@ module Cor1440Gen
       else
         return [-1, '#', -1, '#', -1, '#', -1, '#']
       end
-
       resind = -1
       hombres = -1
       mujeres = -1
@@ -96,6 +95,17 @@ module Cor1440Gen
         where('fecha <= ?', ffin).
         pluck(:id).uniq
       if contar == :personas
+        if ind.id == 214
+          ## se escogen solo las actividades que tienen accion juridica con 
+          ## plan estrategico 1. actividadpf 125
+          lac = Cor1440Gen::Actividad.where(id: lac).
+            joins(:actividadpf).
+            where('cor1440_gen_actividadpf.id = 125').
+            pluck(:id).uniq
+        end
+        asistentes = Cor1440Gen::Asistencia.joins(:persona).
+          where(actividad_id: lac).
+          where('sip_persona.sexo = \'M\'').count
         ## Calcula Hombres 
         asistentes = Cor1440Gen::Asistencia.joins(:persona).
           where(actividad_id: lac).

--- a/app/controllers/cor1440_gen/mindicadorespf_controller.rb
+++ b/app/controllers/cor1440_gen/mindicadorespf_controller.rb
@@ -105,7 +105,8 @@ module Cor1440Gen
           joins('JOIN sip_persona ON sip_persona.id=sivel2_gen_victima.id_persona').
           joins('JOIN sivel2_sjr_actividad_casosjr ON casosjr_id=sivel2_gen_victima.id_caso').
           where('sip_persona.sexo = \'M\'').
-          where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).count
+          where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).
+          where('fechadesagregacion IS NULL OR fechadesagregacion > ?', ffin).count
 
         mujeres = Cor1440Gen::Asistencia.joins(:persona).
           where(actividad_id: lac).
@@ -115,7 +116,8 @@ module Cor1440Gen
           joins('JOIN sip_persona ON sip_persona.id=sivel2_gen_victima.id_persona').
           joins('JOIN sivel2_sjr_actividad_casosjr ON casosjr_id=sivel2_gen_victima.id_caso').
           where('sip_persona.sexo = \'F\'').
-          where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).count
+          where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).
+          where('fechadesagregacion IS NULL OR fechadesagregacion > ?', ffin).count
 
         sinsexo = Cor1440Gen::Asistencia.joins(:persona).
           where(actividad_id: lac).
@@ -125,8 +127,8 @@ module Cor1440Gen
           joins('JOIN sip_persona ON sip_persona.id=sivel2_gen_victima.id_persona').
           joins('JOIN sivel2_sjr_actividad_casosjr ON casosjr_id=sivel2_gen_victima.id_caso').
           where('sip_persona.sexo <> \'M\' AND sip_persona.sexo <> \'F\'').
-          where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).count
-
+          where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).
+          where('fechadesagregacion IS NULL OR fechadesagregacion > ?', ffin).count
 
         resind = hombres + mujeres + sinsexo
       elsif contar == :actividades

--- a/app/controllers/cor1440_gen/mindicadorespf_controller.rb
+++ b/app/controllers/cor1440_gen/mindicadorespf_controller.rb
@@ -125,7 +125,6 @@ module Cor1440Gen
           where(:'sivel2_sjr_actividad_casosjr.actividad_id' => lac).
           where('fechadesagregacion IS NULL OR fechadesagregacion > ?', ffin).
           where.not(:'sip_persona.id' => idscontactos).uniq.count
-        byebug
         hombres = asistentes + benef_dir + benef_indir
 
         ## CLACULA MUJERES


### PR DESCRIPTION
Esta validacion de contar personas unicas tambien aplica para los demas indicadores