### PR TITLE
R153 En detalle financiero de una actividad cambiar forma de llenar Número total de entregas y Número de esta asistencia

### DIFF
--- a/app/assets/javascripts/actividad.js.coffee
+++ b/app/assets/javascripts/actividad.js.coffee
@@ -290,5 +290,15 @@ $(document).on('focusin', '.actividad_detallefinanciero_persona', (e, papa) ->
   jrs_refresca_posibles_beneficiarios_casos()
 )
 
+# En caso de que en detalle financiero 
+# se seleccione el proyecto financiero 
 
-
+$(document).on('change', 'select[id^=actividad_detallefinanciero_attributes][id$=_convenioactividad]', (e) ->
+  console.log("entra")
+  ## if $(this).val() == "10"
+  idpi = $(this).parent().parent().next().find("[id$=_persona_ids]").attr('id')
+  beneficiarios = $("#"+ idpi).val()
+  if beneficiarios.length > 0 
+    idconvenio = $(this).val()
+    debugger
+)

--- a/app/assets/javascripts/actividad.js.coffee
+++ b/app/assets/javascripts/actividad.js.coffee
@@ -295,10 +295,29 @@ $(document).on('focusin', '.actividad_detallefinanciero_persona', (e, papa) ->
 
 $(document).on('change', 'select[id^=actividad_detallefinanciero_attributes][id$=_convenioactividad]', (e) ->
   console.log("entra")
-  ## if $(this).val() == "10"
   idpi = $(this).parent().parent().next().find("[id$=_persona_ids]").attr('id')
+  eleconvenio = $(this)
   beneficiarios = $("#"+ idpi).val()
   if beneficiarios.length > 0 
     idconvenio = $(this).val()
-    debugger
+    root = window
+    rutac = root.puntomontaje + 'revisaben_detalle'
+    $.ajax({
+      url: rutac, 
+      data: {pf: idconvenio, ben_ids: beneficiarios},
+      dataType: 'json',
+      method: 'GET'
+    }).fail( (jqXHR, texto) ->
+      alert('Error - ')
+    ).done( (datos, r) ->
+      if datos.respuesta == true
+        elenm = $(eleconvenio.parent().parent().siblings()[8]).find("[id$=_numeromeses]")
+        elena = $(eleconvenio.parent().parent().siblings()[8]).find("[id$=_numeroasistencia]")
+        elenm.val(datos.numeromeses)
+        elenm.prop('disabled', 'disabled');
+        elenm.trigger('chosen:updated')
+        sip_remplaza_opciones_select(elena.attr('id'), datos.opsna, true);
+      console.log(datos)
+    )
+
 )

--- a/app/assets/javascripts/actividad.js.coffee
+++ b/app/assets/javascripts/actividad.js.coffee
@@ -291,33 +291,47 @@ $(document).on('focusin', '.actividad_detallefinanciero_persona', (e, papa) ->
 )
 
 # En caso de que en detalle financiero 
-# se seleccione el proyecto financiero 
+# se seleccione el proyecto financiero y convenio se busca si han habido otros
+# detalles financierosc con este poryecto/convenio y estos beneficiarios
+# así, se deshabilita el campo numeromeses y se redefinen opciones de
+# numeroasistencia
 
+$(document).on('change', 'select[id^=actividad_detallefinanciero_attributes][id$=_persona_ids]', (e) ->
+  beneficiarios = $(this).val()
+  eleconvenio = $(this).parent().parent().prev().find("[id$=_convenioactividad]")
+  busca_detallesfinancieros_anteriores(beneficiarios, eleconvenio)
+)
 $(document).on('change', 'select[id^=actividad_detallefinanciero_attributes][id$=_convenioactividad]', (e) ->
-  console.log("entra")
   idpi = $(this).parent().parent().next().find("[id$=_persona_ids]").attr('id')
   eleconvenio = $(this)
   beneficiarios = $("#"+ idpi).val()
-  if beneficiarios.length > 0 
-    idconvenio = $(this).val()
+  busca_detallesfinancieros_anteriores(beneficiarios, eleconvenio)
+)
+
+@busca_detallesfinancieros_anteriores = (beneficiarios, eleconvenio) ->
+  convenio = eleconvenio.val()
+  elenm = $(eleconvenio.parent().parent().siblings()[8]).find("[id$=_numeromeses]")
+  elena = $(eleconvenio.parent().parent().siblings()[9]).find("[id$=_numeroasistencia]")
+  if beneficiarios.length > 0 && convenio
     root = window
     rutac = root.puntomontaje + 'revisaben_detalle'
     $.ajax({
       url: rutac, 
-      data: {pf: idconvenio, ben_ids: beneficiarios},
+      data: {pf: convenio, ben_ids: beneficiarios},
       dataType: 'json',
       method: 'GET'
     }).fail( (jqXHR, texto) ->
       alert('Error - ')
     ).done( (datos, r) ->
       if datos.respuesta == true
-        elenm = $(eleconvenio.parent().parent().siblings()[8]).find("[id$=_numeromeses]")
-        elena = $(eleconvenio.parent().parent().siblings()[8]).find("[id$=_numeroasistencia]")
         elenm.val(datos.numeromeses)
         elenm.prop('disabled', 'disabled');
         elenm.trigger('chosen:updated')
-        sip_remplaza_opciones_select(elena.attr('id'), datos.opsna, true);
-      console.log(datos)
+        sip_remplaza_opciones_select(elena.attr('id'), datos.asistencias, true);
+      else
+         elenm.removeAttr('disabled');
+         elenm.val("")
+         elenm.trigger('chosen:updated')
+         elena.empty()
+         elena.trigger('chosen:updated')
     )
-
-)

--- a/app/controllers/cor1440_gen/actividades_controller.rb
+++ b/app/controllers/cor1440_gen/actividades_controller.rb
@@ -130,6 +130,29 @@ module Cor1440Gen
     end
 
 
+    def revisaben_detalle
+      pfapf = params[:pf]
+      beneficiarios = params[:ben_ids].map{|b| b.to_i}
+      pf = Cor1440Gen::Proyectofinanciero.where(nombre: pfapf.split(" - ")[0])[0]
+      apf = Cor1440Gen::Actividadpf.where(titulo: pfapf.split(" - ")[1])[0]
+      dfs = Detallefinanciero.where(proyectofinanciero_id: pf.id).where(actividadpf_id: apf.id)
+      respuesta = false
+      nm = 0
+      na = []
+      dfs.each do |df|
+        if df.persona.pluck(:id) == beneficiarios
+          respuesta = true
+          nm = df.numeromeses if df.numeromeses > nm
+          na.push(df.numeroasistencia)
+        end
+      end
+      opna = [*1..nm] - na
+      opsna = opna.map{|op| {id: op, nombre: op}}
+      respond_to do |format|
+        format.json { render json: {respuesta: respuesta, numeromeses: nm, asistencias: opsna} }
+      end
+    end
+
     # Restringe más para conteo por beneficiario
     def filtra_contarb_actividad_por_parametros(contarb_actividad)
       @contarb_oficinaid = nil

--- a/app/controllers/cor1440_gen/actividades_controller.rb
+++ b/app/controllers/cor1440_gen/actividades_controller.rb
@@ -147,7 +147,7 @@ module Cor1440Gen
         end
       end
       opna = [*1..nm] - na
-      opsna = opna.map{|op| {id: op, nombre: op}}
+      opsna = opna.map{|op| {"id": op, "nombre": op}}
       respond_to do |format|
         format.json { render json: {respuesta: respuesta, numeromeses: nm, asistencias: opsna} }
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
 
   get '/detallesfinancieros/nuevo' => 'detallesfinancieros#nuevo'
   
+  get '/revisaben_detalle' => 'cor1440_gen/actividades#revisaben_detalle'
 
   root "sip/hogar#index"
 


### PR DESCRIPTION
Se probó:
1. Al escoger los beneficiarios y después el proyecto/convenio 
2. A escoger primero el proyecto/convenio-actividadpf y liego los beneficiarios
3. se hace limitan los cmapos solo si son todos los beneficiarios proyecto y actividadpf de detalles anteriores.
4. No solo se deshabilita sino que se asigna primero el numeromeses registrado en los detalles anteriores (debería ser siempre el mismo), pero si por alguna razón son dierentes, se elige el mayor, sel e asigna al select y después ya se deshabilita
5. de esas opciones de numeromeses (numero de entregas), se exluyen las encontradas en detalles anteriores y se re definen las opciones del select de numeroasistencia
6. en caso de que haya entrado a este caso y se hayan cambiado los campos, pero despues se grega un beneficiario adicional , se cuenta como un detalle financiero nuevo y se resetan los campos como inciialmente estaban.

Se implementó con un llamado ajax de javascript a  rails con un método en el controlador de actividades.